### PR TITLE
feat: add TDH2 demo

### DIFF
--- a/demos-cpp/tdh2/CMakeLists.txt
+++ b/demos-cpp/tdh2/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(mpc-demo-tdh2 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(REPO_CMAKE_DIR ${CMAKE_CURRENT_LIST_DIR}/../../cmake)
+
+include(${REPO_CMAKE_DIR}/macros.cmake)
+include(${REPO_CMAKE_DIR}/arch.cmake)
+include(${REPO_CMAKE_DIR}/openssl.cmake)
+include(${REPO_CMAKE_DIR}/compilation_flags.cmake)
+
+set(CBMPC_SOURCE_DIR /usr/local/opt/cbmpc/)
+
+add_executable(mpc-demo-tdh2 main.cpp)
+link_openssl(mpc-demo-tdh2)
+
+target_include_directories(mpc-demo-tdh2 PUBLIC ${CBMPC_SOURCE_DIR}/include)
+target_link_directories(mpc-demo-tdh2 PUBLIC ${CBMPC_SOURCE_DIR}/lib)
+target_link_libraries(mpc-demo-tdh2 PRIVATE cbmpc)
+
+if(IS_LINUX)
+  link_openssl(mpc-demo-tdh2)
+endif()
+

--- a/demos-cpp/tdh2/main.cpp
+++ b/demos-cpp/tdh2/main.cpp
@@ -1,0 +1,71 @@
+#include <iostream>
+#include <vector>
+
+#include <cbmpc/crypto/ro.h>
+#include <cbmpc/crypto/secret_sharing.h>
+#include <cbmpc/crypto/tdh2.h>
+
+using namespace coinbase::crypto;
+
+// Generate additive shares for TDH2.
+static void generate_additive_shares(int n, tdh2::public_key_t& enc_key, tdh2::pub_shares_t& pub_shares,
+                                     std::vector<tdh2::private_share_t>& dec_shares, ecurve_t curve) {
+  const ecc_point_t& G = curve.generator();
+
+  bn_t x = curve.get_random_value();
+
+  std::vector<bn_t> prv_shares = ss::share_and(curve.order(), x, n);
+  pub_shares.resize(n);
+  for (int i = 0; i < n; i++) {
+    pub_shares[i] = prv_shares[i] * G;
+  }
+  enc_key.Q = x * G;
+  enc_key.Gamma = ro::hash_curve(mem_t("TDH2-Gamma"), enc_key.Q).curve(curve);
+
+  dec_shares.resize(n);
+  for (int i = 0; i < n; i++) {
+    dec_shares[i].x = prv_shares[i];
+    dec_shares[i].pid = i + 1;
+    dec_shares[i].pub_key = enc_key;
+  }
+}
+
+int main() {
+  const int n = 3;  // number of nodes
+  ecurve_t curve = curve_p256;
+
+  // ==== Decentralized key generation ====
+  tdh2::public_key_t enc_key;
+  tdh2::pub_shares_t pub_shares;
+  std::vector<tdh2::private_share_t> dec_shares;
+  generate_additive_shares(n, enc_key, pub_shares, dec_shares, curve);
+  std::cout << "Public key generated.\n";
+
+  // ==== Threshold encryption ====
+  buf_t plain = buf_t("Hello TDH2");
+  buf_t label = buf_t("demo");
+  tdh2::ciphertext_t ciphertext = enc_key.encrypt(plain, label);
+  if (ciphertext.verify(enc_key, label) != SUCCESS) {
+    std::cout << "Ciphertext verification failed\n";
+    return 1;
+  }
+  std::cout << "Ciphertext created and verified.\n";
+
+  // ==== Partial decryptions by each node ====
+  tdh2::partial_decryptions_t partials(n);
+  for (int i = 0; i < n; i++) {
+    dec_shares[i].decrypt(ciphertext, label, partials[i]);
+    std::cout << "Node " << (i + 1) << " computed partial decryption.\n";
+  }
+
+  // ==== Combine partial decryptions ====
+  buf_t decrypted;
+  if (tdh2::combine_additive(enc_key, pub_shares, label, partials, ciphertext, decrypted) != SUCCESS) {
+    std::cout << "Combine failed\n";
+    return 1;
+  }
+  std::cout << "Decrypted message: " << std::string(reinterpret_cast<char*>(decrypted.data()), decrypted.size())
+            << "\n";
+
+  return 0;
+}

--- a/scripts/run-demos.sh
+++ b/scripts/run-demos.sh
@@ -11,7 +11,7 @@ ROOT_PATH="${SCRIPT_PATH}/.."
 DEMOS_CPP_DIR="${ROOT_PATH}/demos-cpp"
 DEMOS_GO_DIR="${ROOT_PATH}/demos-go/examples"
 
-CPP_DEMOS=("basic_primitive"  "zk")
+CPP_DEMOS=("basic_primitive" "tdh2" "zk")
 GO_DEMOS=("access-structure" "agreerandom" "ecdsa-2pc" "ecdsa-mpc-with-backup" "zk")
 
 clean() {

--- a/scripts/setup-run-tdh2-demo.sh
+++ b/scripts/setup-run-tdh2-demo.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+# This script sets up dependencies, builds the cb-mpc library, and runs the TDH2 demo.
+# It assumes it is executed from the root of a freshly cloned repository on a Debian/Ubuntu system.
+
+# Install build dependencies
+sudo apt-get update
+sudo apt-get install -y build-essential cmake curl rsync git
+
+# Initialize submodules (required for vendored dependencies)
+git submodule update --init --recursive
+
+# Build a minimal static OpenSSL used by the library
+make openssl-linux
+
+# Build the cb-mpc library (without running tests)
+make build-no-test
+
+# Install the library headers and archive into /usr/local/opt/cbmpc
+sudo make install
+
+# Build the TDH2 demo
+cd demos-cpp/tdh2
+cmake -B build
+cmake --build build
+
+# Run the demo binary
+./build/mpc-demo-tdh2
+


### PR DESCRIPTION
## Summary
- add C++ TDH2 demo showing decentralized key generation, share distribution, and threshold encrypt/decrypt
- include new demo in run-demos script
- provide setup script to install deps, build library and run TDH2 demo

## Testing
- `./scripts/setup-run-tdh2-demo.sh` *(failed: apt repository access was forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_689b7ea2f54c83289877ed9ea35941ba